### PR TITLE
Use tmpfile extension

### DIFF
--- a/beaker_puppet_helpers.gemspec
+++ b/beaker_puppet_helpers.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '>= 4', '< 6'
+  s.add_runtime_dependency 'beaker', '>= 5.8.1', '< 6'
   s.add_runtime_dependency 'puppet-modulebuilder', '>= 0.3', '< 2'
 end

--- a/lib/beaker_puppet_helpers/dsl.rb
+++ b/lib/beaker_puppet_helpers/dsl.rb
@@ -173,7 +173,7 @@ module BeakerPuppetHelpers
 
         puppet_apply_opts = host[:default_apply_opts].merge(puppet_apply_opts) if host[:default_apply_opts].respond_to? :merge
 
-        file_path = host.tmpfile(%(apply_manifest_#{Time.now.strftime('%H%M%S%L')}.pp))
+        file_path = host.tmpfile(%(apply_manifest_#{Time.now.strftime('%H%M%S%L')}), '.pp')
         begin
           create_remote_file(host, file_path, "#{manifest}\n")
 

--- a/lib/beaker_puppet_helpers/install_utils.rb
+++ b/lib/beaker_puppet_helpers/install_utils.rb
@@ -99,8 +99,7 @@ module BeakerPuppetHelpers
     def self.wget_on(host, url)
       extension = File.extname(url)
       name = File.basename(url, extension)
-      # Can't use host.tmpfile since we need to set an extension
-      target = host.exec(Beaker::Command.new("mktemp -t '#{name}-XXXXXX#{extension}'")).stdout.strip
+      target = host.tmpfile(name, extension)
       begin
         host.exec(Beaker::Command.new("wget -O '#{target}' '#{url}'"))
         yield target

--- a/lib/beaker_puppet_helpers/module_utils.rb
+++ b/lib/beaker_puppet_helpers/module_utils.rb
@@ -44,7 +44,7 @@ module BeakerPuppetHelpers
       source_path = builder.build
       begin
         block_on hosts do |host|
-          target_file = host.tmpfile('puppet_module')
+          target_file = host.tmpfile('puppet_module', '.tar.gz')
           begin
             host.do_scp_to(source_path, target_file, {})
             install_puppet_module_via_pmt_on(host, target_file)

--- a/spec/beaker_puppet_helpers/module_utils_spec.rb
+++ b/spec/beaker_puppet_helpers/module_utils_spec.rb
@@ -97,7 +97,7 @@ describe BeakerPuppetHelpers::ModuleUtils do
       expect(Puppet::Modulebuilder::Builder).to receive(:new).with('/path/to/module').and_return(builder)
       expect(builder).to receive(:build).and_return('/path/to/tarball')
 
-      expect(host).to receive(:tmpfile).with('puppet_module').and_return('temp')
+      expect(host).to receive(:tmpfile).with('puppet_module', '.tar.gz').and_return('temp')
       expect(host).to receive(:do_scp_to).with('/path/to/tarball', 'temp', {})
       expect(dsl).to receive(:install_puppet_module_via_pmt_on).with(host, 'temp')
       expect(host).to receive(:rm_rf).with('temp')


### PR DESCRIPTION
Having a proper extension, even for temporary files is much cleaner.

Depends on https://github.com/voxpupuli/beaker/pull/1735