### PR TITLE
Send arguments as keyword arguments & Test on Ruby 3.1 and 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.7"
+          - "3.2"
+          - "3.1"
           - "3.0"
+          - "2.7"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3

--- a/lib/beaker_puppet_helpers/dsl.rb
+++ b/lib/beaker_puppet_helpers/dsl.rb
@@ -171,7 +171,7 @@ module BeakerPuppetHelpers
         begin
           create_remote_file(host, file_path, "#{manifest}\n")
 
-          on host, Beaker::PuppetCommand.new('apply', file_path, puppet_apply_opts), on_options, &block
+          on(host, Beaker::PuppetCommand.new('apply', file_path, puppet_apply_opts), **on_options, &block)
         ensure
           host.rm_rf(file_path)
         end

--- a/spec/beaker_puppet_helpers/dsl_spec.rb
+++ b/spec/beaker_puppet_helpers/dsl_spec.rb
@@ -73,9 +73,9 @@ describe BeakerPuppetHelpers::DSL do
       the_hosts.each do |host|
         allow(dsl).to receive(:on).with(host, 'puppet_command', acceptable_exit_codes: [0])
       end
-      expect(dsl).to receive(:block_on).with(anything, run_in_parallel: true)
+      expect(dsl).to receive(:block_on).with(anything, { run_in_parallel: true })
 
-      dsl.apply_manifest_on(the_hosts, 'include foobar', { run_in_parallel: true })
+      dsl.apply_manifest_on(the_hosts, 'include foobar', run_in_parallel: true)
     end
 
     it 'adds acceptable exit codes with :catch_failures' do


### PR DESCRIPTION
Rather than passing options as a hash, this passes them as keyword arguments. That makes the tests pass on Ruby 3. Since the tests pass on Ruby 3.0, it's also time to verify Ruby 3.1 & 3.2.