### PR TITLE
Add support for `--show_diff`

### DIFF
--- a/lib/beaker_puppet_helpers/dsl.rb
+++ b/lib/beaker_puppet_helpers/dsl.rb
@@ -94,6 +94,10 @@ module BeakerPuppetHelpers
     #                         will be passed to the 'puppet apply' command.
     # @option opts [Boolean] :run_in_parallel Whether to run on each host in parallel.
     #
+    # @option opts [Boolean]  :show_diff (false) If this option exists,
+    #                         the "--show_diff=true" command line parameter
+    #                         will be passed to the 'puppet apply' command.
+    #
     # @param [Block] block This method will yield to a block of code passed
     #                      by the caller; this can be used for additional
     #                      validation, etc.
@@ -118,6 +122,7 @@ module BeakerPuppetHelpers
         puppet_apply_opts[:modulepath] = opts[:modulepath] if opts[:modulepath]
         puppet_apply_opts[:hiera_config] = opts[:hiera_config] if opts[:hiera_config]
         puppet_apply_opts[:noop] = nil if opts[:noop]
+        puppet_apply_opts[:show_diff] = nil if opts[:show_diff]
 
         # From puppet help:
         # "... an exit code of '2' means there were changes, an exit code of

--- a/lib/beaker_puppet_helpers/dsl.rb
+++ b/lib/beaker_puppet_helpers/dsl.rb
@@ -89,10 +89,11 @@ module BeakerPuppetHelpers
     #
     # @option opts [String]   :hiera_config The path of the hiera.yaml configuration.
     #
-    # @option opts [String]   :debug (false) If this option exists,
+    # @option opts [Boolean]  :debug (false) If this option exists,
     #                         the "--debug" command line parameter
     #                         will be passed to the 'puppet apply' command.
-    # @option opts [Boolean] :run_in_parallel Whether to run on each host in parallel.
+    #
+    # @option opts [Boolean]  :run_in_parallel Whether to run on each host in parallel.
     #
     # @option opts [Boolean]  :show_diff (false) If this option exists,
     #                         the "--show_diff=true" command line parameter

--- a/spec/beaker_puppet_helpers/dsl_spec.rb
+++ b/spec/beaker_puppet_helpers/dsl_spec.rb
@@ -166,6 +166,14 @@ describe BeakerPuppetHelpers::DSL do
 
       dsl.apply_manifest_on(agent, 'class { "boo": }', debug: true)
     end
+
+    it 'can set the --show_diff flag' do
+      expect(dsl).to receive(:create_remote_file).and_return(true)
+      expect(Beaker::PuppetCommand).to receive(:new).with('apply', anything, include(show_diff: nil)).and_return('puppet_command')
+      expect(dsl).to receive(:on).with(agent, 'puppet_command', acceptable_exit_codes: [0])
+
+      dsl.apply_manifest_on(agent, 'class { "boo": }', show_diff: true)
+    end
   end
 
   describe '#apply_manifest' do


### PR DESCRIPTION
Some CI failures are easier to fix when we have a diff of changes (e.g.
when acceptance tests check for idempotentency and some changes happen).

Add support for the `--show_diff` parameter to enable it.
