### PR TITLE
Unbreak CI with ArchLinux

### DIFF
--- a/lib/beaker_puppet_helpers/install_utils.rb
+++ b/lib/beaker_puppet_helpers/install_utils.rb
@@ -64,6 +64,8 @@ module BeakerPuppetHelpers
 
         # On Debian we can't count on /etc/profile.d
         host.add_env_var('PATH', '/opt/puppetlabs/bin')
+      when 'archlinux'
+        # Do nothing
       else
         raise "No repository installation step for #{variant} yet..."
       end


### PR DESCRIPTION
ArchLinux has puppet packages in its main package repository, no need to add an extra one.

Adjust the `install_puppet_release_repo_on()` function to do nothing on ArchLinux rather than raising an error.

I opened a test PR that use this code and it seems to help:
https://github.com/voxpupuli/puppet-python/pull/662