### PR TITLE
fix typo in EL package selection

### DIFF
--- a/lib/beaker_puppet_helpers/install_utils.rb
+++ b/lib/beaker_puppet_helpers/install_utils.rb
@@ -78,7 +78,7 @@ module BeakerPuppetHelpers
     # @return [String] The Puppet package name
     def self.puppet_package_name(host, prefer_aio: true)
       case host['packaging_platform'].split('-', 3).first
-      when /el-|fedora|sles|cisco_|debian|ubuntu/
+      when /el|fedora|sles|cisco_|debian|ubuntu/
         prefer_aio ? 'puppet-agent' : 'puppet'
       when /freebsd/
         'sysutils/puppet'


### PR DESCRIPTION
```
irb(main):003:0> 'el-8-x86_64'.split('-', 3)
=> ["el", "8", "x86_64"]
irb(main):004:0>
```

This worked by accident on Puppet 6/7 because the puppet-agent packages have a `provides: puppet` in the rpmspec. That's not the case anymore for Puppet 8. Because of that we noticed te bug in install_utils.