### PR TITLE
Always use puppet-agent for Debian 12+ & Ubuntu 23.04+

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ DESC
 task :acceptance do
   hosts = {
     aio: %w[centos7 centos8 debian10 debian11],
-    foss: %w[debian10 debian11],
+    foss: %w[debian10 debian11 debian12],
   }
   default_hosts = hosts.map { |type, h| h.map { |host| "#{host}-64{type=#{type}}" }.join('-') }.join('-')
   hosts = ENV['BEAKER_HOSTS'] || default_hosts

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ DESC
 task :acceptance do
   hosts = {
     aio: %w[centos7 centos8 debian10 debian11],
-    foss: %w[debian10 debian11 debian12],
+    foss: %w[debian10 debian11 debian12 fedora37 fedora38],
   }
   default_hosts = hosts.map { |type, h| h.map { |host| "#{host}-64{type=#{type}}" }.join('-') }.join('-')
   hosts = ENV['BEAKER_HOSTS'] || default_hosts

--- a/lib/beaker_puppet_helpers/install_utils.rb
+++ b/lib/beaker_puppet_helpers/install_utils.rb
@@ -78,10 +78,16 @@ module BeakerPuppetHelpers
     # @return [String] The Puppet package name
     def self.puppet_package_name(host, prefer_aio: true)
       case host['packaging_platform'].split('-', 3).first
-      when /el|fedora|sles|cisco_|debian|ubuntu/
+      when 'debian'
+        # 12 started to ship puppet-agent with puppet as a legacy package
+        prefer_aio || host['packaging_platform'].split('-', 3)[1].to_i >= 12 ? 'puppet-agent' : 'puppet'
+      when /el|fedora|sles|cisco_/
         prefer_aio ? 'puppet-agent' : 'puppet'
       when /freebsd/
         'sysutils/puppet'
+      when 'ubuntu'
+        # 23.04 started to ship puppet-agent with puppet as a legacy package
+        prefer_aio || host['packaging_platform'].split('-', 3)[1].to_i >= 2304 ? 'puppet-agent' : 'puppet'
       else
         'puppet'
       end


### PR DESCRIPTION
Debian 12 has started to ship puppet-agent as a package and puppet is just a compatibility wrapper. Older versions only have Puppet, but they're so old that we don't consider them today anymore and only AIO should be used.