### PR TITLE
New beaker helper `bolt_supported` to show bolt availability

### DIFF
--- a/lib/beaker_puppet_helpers/dsl.rb
+++ b/lib/beaker_puppet_helpers/dsl.rb
@@ -224,5 +224,30 @@ module BeakerPuppetHelpers
     def fact(name, opts = {})
       fact_on(default, name, opts)
     end
+
+    # Show if bolt package is available
+    #
+    # @param [Beaker::Host] host
+    # @return True if package is available.
+    #
+    def bolt_supported?(host = default)
+      #
+      # Supported platforms
+      # https://github.com/puppetlabs/bolt/blob/main/documentation/bolt_installing.md
+      # https://github.com/puppetlabs/bolt-vanagon/tree/main/configs/platforms
+
+      case host['packaging_platform'].split('-', 3)[0, 1]
+      when %w[el 7], %w[el 8], %w[el 9],
+        %w[debian 10], %w[debian 11],
+        ['ubuntu', '20.04'], ['ubuntu', '22.04'],
+        %w[osx 11], %w[osx 12],
+        %w[sles 12], %w[sles 15],
+        %w[fedora 36],
+        %w[windows 2012r2]
+        true
+      else
+        false
+      end
+    end
   end
 end


### PR DESCRIPTION
Can be used in `spec/spec_helper_acceptance.rb` as:

```ruby
if bolt_supported(host)
  host.install_package('puppet-bolt')
end
```

bolt_supported returns `true` or `false` depending on if a bolt package is available for a particular platform.