### PR TITLE
CI: Use voxpupuli/ruby-version@v1 / Add Ruby 3.4 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     if: github.repository_owner == 'voxpupuli'
     steps:
       - uses: actions/checkout@v4
-      - name: Install Ruby 3.3
+      - name: Install Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler: 'none'
       - name: Build gem
         run: gem build --strict --verbose *.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,30 +11,29 @@ env:
   BUNDLE_WITHOUT: release
 
 jobs:
-  rubocop:
+  rubocop_and_matrix:
     runs-on: ubuntu-latest
-    name: Rubocop
+    outputs:
+      ruby: ${{ steps.ruby.outputs.versions }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - name: Rubocop
         run: bundle exec rake rubocop
+      - id: ruby
+        uses: voxpupuli/ruby-version@v1
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs: rubocop_and_matrix
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - "3.3"
-          - "3.2"
-          - "3.1"
-          - "3.0"
-          - "2.7"
+        ruby: ${{ fromJSON(needs.rubocop_and_matrix.outputs.ruby) }}
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +51,6 @@ jobs:
 
   tests:
     needs:
-      - rubocop
       - build
     runs-on: ubuntu-latest
     name: Test suite

--- a/beaker_puppet_helpers.gemspec
+++ b/beaker_puppet_helpers.gemspec
@@ -18,4 +18,7 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_dependency 'beaker', '>= 5.8.1', '< 7'
   s.add_dependency 'puppet-modulebuilder', '>= 0.3', '< 3'
+  # we need to declare both dependencies explicitly on Ruby 3.4+
+  s.add_dependency 'base64', '~> 0.2.0'
+  s.add_dependency 'benchmark', '~> 0.4.0'
 end


### PR DESCRIPTION
This new action generates a CI matrix based on all supported Ruby versions.