### PR TITLE
Remove base64 & benchmark dependencies

### DIFF
--- a/beaker_puppet_helpers.gemspec
+++ b/beaker_puppet_helpers.gemspec
@@ -18,7 +18,4 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_dependency 'beaker', '>= 5.8.1', '< 7'
   s.add_dependency 'puppet-modulebuilder', '>= 0.3', '< 3'
-  # we need to declare both dependencies explicitly on Ruby 3.4+
-  s.add_dependency 'base64', '>= 0.2', '< 1'
-  s.add_dependency 'benchmark', '~> 0.4.0'
 end


### PR DESCRIPTION
Those two gems are actually dependencies of the beaker gem and were
added here by accident. The tests pass fine without them:

unit:
```
Run bundle exec rake spec

/opt/hostedtoolcache/Ruby/3.4.4/x64/bin/ruby -I/home/runner/work/beaker_puppet_helpers/beaker_puppet_helpers/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.4/lib:/home/runner/work/beaker_puppet_helpers/beaker_puppet_helpers/vendor/bundle/ruby/3.4.0/gems/rspec-support-3.13.4/lib /home/runner/work/beaker_puppet_helpers/beaker_puppet_helpers/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/3.4.0/yaml/store.rb:8: warning: pstore was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add pstore to your Gemfile or gemspec to silence this warning.
...................................
Finished in 0.04855 seconds (files took 0.38335 seconds to load)
35 examples, 0 failures
```

acceptance:

```
Run bundle exec rake acceptance

beaker --hosts=centos9-64{type=aio}-debian11-64{type=aio}-debian12-64{type=aio}-debian10-64{type=foss}-debian11-64{type=foss}-debian12-64{type=foss}-fedora37-64{type=foss}-fedora38-64{type=foss} --tests=acceptance/tests --log-level=debug --preserve-hosts=onfail
/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/3.4.0/yaml/store.rb:8: warning: pstore was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add pstore to your Gemfile or gemspec to silence this warning.
Hosts file 'centos9-64{type=aio}-debian11-64{type=aio}-debian12-64{type=aio}-debian10-64{type=foss}-debian11-64{type=foss}-debian12-64{type=foss}-fedora37-64{type=foss}-fedora38-64{type=foss}' does not exist.
Trying as beaker-hostgenerator input.
```

I assume the dependencies were added here when we were testing against
beaker 6.6.0 or older. Newer releases now have the correct dependencies:

```
bastelfreak@bastelfreak-nb ~/code/beaker $ git grep base64
CHANGELOG.md:- base64: Allow \<1 [\#1931](https://github.com/voxpupuli/beaker/pull/1931) ([bastelfreak](https://github.com/bastelfreak))
beaker.gemspec:  s.add_dependency 'base64', '>= 0.2.0', '< 1'
lib/beaker/dsl/wrappers.rb:require 'base64'
bastelfreak@bastelfreak-nb ~/code/beaker $ git grep benchmark
CHANGELOG.md:- Add `benchmark` dependency for Ruby 3.5 support [\#1920](https://github.com/voxpupuli/beaker/pull/1920) ([bastelfreak](https://github.com/bastelfreak))
beaker.gemspec:  s.add_dependency 'benchmark', '>= 0.3', '< 0.5'
lib/beaker/host.rb:require 'benchmark'
lib/beaker/test_case.rb:require 'benchmark'
bastelfreak@bastelfreak-nb ~/code/beaker $ git diff 6.6.0..6.8.0 -- beaker.gemspec
diff --git a/beaker.gemspec b/beaker.gemspec
index 7f58db78..57314cd1 100644
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -19,12 +19,15 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new('>= 2.7')

   # Testing dependencies
-  s.add_development_dependency 'fakefs', '~> 2.4'
+  s.add_development_dependency 'fakefs', '>= 2.4', '< 4'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'voxpupuli-rubocop', '~> 3.0.0'
+  s.add_development_dependency 'voxpupuli-rubocop', '~> 3.1.0'

   # Run time dependencies
+  # Required for Ruby 3.3+ support
+  s.add_dependency 'base64', '>= 0.2.0', '< 1'
+  s.add_dependency 'benchmark', '>= 0.3', '< 0.5'
   # we cannot require 1.0.2 because that requires Ruby 3.1
   s.add_dependency 'minitar', '>= 0.12', '< 2'
   s.add_dependency 'minitest', '~> 5.4'
bastelfreak@bastelfreak-nb ~/code/beaker $
```