### PR TITLE
CI: Dont test on Debian 10

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ DESC
 task :acceptance do
   hosts = {
     aio: %w[centos9 debian11 debian12],
-    foss: %w[debian10 debian11 debian12 fedora37 fedora38],
+    foss: %w[debian11 debian12 fedora37 fedora38],
   }
   default_hosts = hosts.map { |type, h| h.map { |host| "#{host}-64{type=#{type}}" }.join('-') }.join('-')
   hosts = ENV['BEAKER_HOSTS'] || default_hosts


### PR DESCRIPTION
Debian 10 is EoL and the mirror is gone. The tests don't pass anymore.