### PR TITLE
gemspec: Dont set upper limit for ruby version

### DIFF
--- a/beaker_puppet_helpers.gemspec
+++ b/beaker_puppet_helpers.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = 'For use for the Beaker acceptance testing tool'
   s.license     = 'Apache-2.0'
 
-  s.required_ruby_version = '>= 3.2', '< 4'
+  s.required_ruby_version = '>= 3.2'
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ['lib']


### PR DESCRIPTION
Since each minor release has breaking changes, the upper limit doesn't make sense, and it breaks dependabot.

```
updater | /home/dependabot/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:95:in 'Kernel#eval': (eval at /home/dependabot/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:95):1: syntax errors found (SyntaxError)
198
> 1 | '>= 3.2', '< 4'
199
    |         ^ unexpected ',', ignoring it
200
    |         ^ unexpected ',', expecting end-of-input
```