### PR TITLE
nokogiri: Move from dev to runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-gem 'nokogiri', require: false
 gem 'open-uri', require: false
 gem 'rake', '~> 13.0', groups: %i[development test release]
 

--- a/beaker_puppet_helpers.gemspec
+++ b/beaker_puppet_helpers.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_dependency 'beaker', '>= 5.8.1', '< 8'
+  s.add_dependency 'nokogiri', '~> 1.18', '>= 1.18.10'
   s.add_dependency 'puppet-modulebuilder', '>= 0.3', '< 3'
 
   s.add_development_dependency 'voxpupuli-rubocop', '~> 4.1.0'


### PR DESCRIPTION
nokogiri is used in lib/beaker_puppet_helpers/windows_utils.rb